### PR TITLE
Fix paths not existing for file copy

### DIFF
--- a/src/extensions.py
+++ b/src/extensions.py
@@ -352,6 +352,7 @@ class ExtensionLoader:
         Args:
             file_path: the path of the file to copy 
         """
+        os.makedirs(os.path.join(self.extension_dir, os.path.basename(file_path)), exist_ok=True)
         shutil.copyfile(file_path, os.path.join(self.extension_dir, os.path.basename(file_path)))
 
     def get_extension_by_id(self, id: str) -> NewelleExtension | None:

--- a/src/smart_prompt.py
+++ b/src/smart_prompt.py
@@ -115,8 +115,10 @@ class LogicalRegressionHandler(SmartPromptHandler):
     def check_files(self):
         default_model = f"NyaMedium_{self.version}_{256}.pkl"
         if not os.path.isfile(os.path.join(self.models_dir, default_model)):
+            os.makedirs(self.models_dir, exist_ok=True)
             shutil.copy(os.path.join(BASE_PATH + "/smart-prompts", default_model), os.path.join(self.models_dir, default_model))
         if not os.path.isfile(os.path.expanduser("~/.cache/wordllama/tokenizers/l2_supercat_tokenizer_config.json")):
+            os.makedirs(os.path.expanduser("~/.cache/wordllama/tokenizers/"), exist_ok=True)
             shutil.copy(os.path.join(BASE_PATH + "/smart-prompts", "l2_supercat_tokenizer_config.json"), os.path.expanduser("~/.cache/wordllama/tokenizers/l2_supercat_tokenizer_config.json"))
 
     @staticmethod


### PR DESCRIPTION
I recently deleted my .cache dir and the settings wouldn't open anymore. There was an error indicating the copy of some files failed. This should now be fixed by ensuring the directory exists before copying files.