### PR TITLE
Live 2D motion fix

### DIFF
--- a/src/handlers/avatar/live2d_handler.py
+++ b/src/handlers/avatar/live2d_handler.py
@@ -224,8 +224,7 @@ class Live2DHandler(AvatarHandler):
             name = self.get_setting("Expression " + motion, False)
             if name is not None:
                 r.append(name)
-            else:
-                if type(motion) is str:
+            elif type(motion) is str:
                     r.append(motion)
         return r
 


### PR DESCRIPTION
Live 2D motions (not expressions) are not detected and injected to prompt, also not played. This is due to a faulty type check. 

In the get_motions() method of the Live2DHandler class, the loop through the motions from get_motions_raw() first check for a name using the get_setting method. When name is None, it proceeds to the else statement to check whether it is a string. However, the code `if motion is str` compares the variable itself with the string type. It is corrected to `if type(motion) is str` to compare the type of the variable with Python type string. The readability is also improved. Instead of a single if statement within the else statement, one elif statement is used. 

Through manual testing, Live 2D models' motions are playing correctly after the modification. 

Here is a simple test I have done to check the type of a string variable in Python 3.13. 
```
>>> mystring = "hello"
>>> mystring is str
False
>>> type(mystring)
<class 'str'>
>>> type(mystring) is str
True
```